### PR TITLE
Catch err early on

### DIFF
--- a/dnsprove.go
+++ b/dnsprove.go
@@ -175,10 +175,10 @@ func (client *Client) verifyRRSet(sig *dns.RRSIG, rrs []dns.RR) ([]proofs.Signed
 	} else {
 		// Find the keys that signed this RRSET
 		sets, err = client.QueryWithProof(dns.TypeDNSKEY, sig.Header().Class, sig.SignerName)
+		if err != nil {
+			return nil, err
+		}
 		keys = sets[len(sets)-1].Rrs
-	}
-	if err != nil {
-		return nil, err
 	}
 
 	// Iterate over the keys looking for one that validly signs our RRSET


### PR DESCRIPTION
When `QueryWithProof` returns empty array `[]`, `sets[len(sets)-1].Rrs` was raising an exception with `panic: runtime error: index out of range`. Once detecting error early on, it shows proper warnings and error message like the below.
```
WARN[05-02|11:11:22] Failed to verify RRSET                   class=IN type=TXT name=_ens.ethlab.xyz. signername=ethlab.xyz. algorithm=RSASHA256 keytag=42999 err="read udp 192.168.1.65:62005->192.168.1.254:53: i/o timeout"
CRIT[05-02|11:11:22] Error resolving                          name=_ens.ethlab.xyz. err="Could not validate IN TXT _ens.ethlab.xyz.: no valid signatures found"
```